### PR TITLE
Improve zh-hant translation

### DIFF
--- a/resources/lang/zh-hant/accounts.php
+++ b/resources/lang/zh-hant/accounts.php
@@ -20,7 +20,7 @@
 
 return [
     'edit' => [
-        'title' => '賬戶設置',
+        'title' => '帳戶設置',
         'title_compact' => '設置',
 
         'avatar' => [
@@ -47,7 +47,7 @@ return [
             'user' => [
                 'user_from' => '當前位置',
                 'user_interests' => '興趣愛好',
-                'user_msnm' => 'Skype',
+                'user_msnm' => 'skype',
                 'user_occ' => '職業',
                 'user_twitter' => '推特',
                 'user_website' => '個人主頁',
@@ -72,9 +72,9 @@ return [
 
     'playstyles' => [
         'title' => '遊戲方式',
-        'mouse' => '鼠標',
+        'mouse' => '滑鼠',
         'keyboard' => '鍵盤',
-        'tablet' => '數位板',
-        'touch' => '觸摸屏',
+        'tablet' => '繪圖板',
+        'touch' => '觸控螢幕',
     ],
 ];

--- a/resources/lang/zh-hant/admin.php
+++ b/resources/lang/zh-hant/admin.php
@@ -22,18 +22,18 @@ return [
     'beatmapsets' => [
         'covers' => [
             'regenerate' => '重新生成',
-            'regenerating' => '重新生成中。。。',
+            'regenerating' => '重新生成中⋯⋯',
             'remove' => '移除',
-            'removing' => '移除中。。。',
+            'removing' => '移除中⋯⋯',
         ],
         'show' => [
             'covers' => '管理譜面封面',
             'discussion' => [
                 '_' => 'Modding v2',
-                'activate' => '啓用',
-                'activate_confirm' => '確認要爲這個譜面啓用 Modding v2 嗎?',
-                'active' => '已啓用',
-                'inactive' => '未啓用',
+                'activate' => '啟用',
+                'activate_confirm' => '確認要爲這個譜面啟用 Modding v2 嗎?',
+                'active' => '已啟用',
+                'inactive' => '未啟用',
             ],
         ],
     ],
@@ -55,7 +55,7 @@ return [
                 'title' => '論壇封面列表',
 
                 'type-title' => [
-                    'default-topic' => '默認板塊封面',
+                    'default-topic' => '預設板塊封面',
                     'main' => '論壇封面',
                 ],
             ],
@@ -70,11 +70,11 @@ return [
 
     'pages' => [
         'root' => [
-            'title' => '管理員控制檯',
+            'title' => '管理員控制台',
 
             'sections' => [
                 'forum' => '論壇',
-                'general' => '常規',
+                'general' => '一般',
                 'store' => '商店',
             ],
         ],
@@ -90,7 +90,7 @@ return [
 
     'users' => [
         'restricted_banner' => [
-            'title' => '該賬戶當前處於限制模式',
+            'title' => '該帳戶當前處於限制模式',
             'message' => '（只有管理員能看見這條信息）',
         ],
     ],

--- a/resources/lang/zh-hant/authorization.php
+++ b/resources/lang/zh-hant/authorization.php
@@ -21,8 +21,8 @@
 return [
     'beatmap_discussion' => [
         'destroy' => [
-            'is_hype' => '無法撤銷推薦',
-            'has_reply' => '無法刪除有回覆的討論。',
+            'is_hype' => '無法撤銷推薦。',
+            'has_reply' => '無法刪除有回覆的討論',
         ],
         'nominate' => [
             'exhausted' => '你今天的提名次數已達上限，請明天再試。',
@@ -32,8 +32,9 @@ return [
         ],
 
         'vote' => [
-            'limit_exceeded' => '在投更多票之前請稍等一會。',
-            'owner' => '不能爲自己的討論投票！',
+            'limit_exceeded' => '在投更多票之前請稍等一會',
+            'owner' => '不能爲自己的討論投票。',
+            'wrong_beatmapset_state' => '只能對等待中的譜面討論進行投票。',
         ],
     ],
 

--- a/resources/lang/zh-hant/beatmap_discussions.php
+++ b/resources/lang/zh-hant/beatmap_discussions.php
@@ -28,7 +28,7 @@ return [
     ],
 
     'events' => [
-        'empty' => '還沒有事件。。。',
+        'empty' => '還沒有事件⋯⋯',
     ],
 
     'index' => [


### PR DESCRIPTION
- 改善地域用詞，符合 OpenCC 臺灣模式 (例如 `鼠標` -> `滑鼠`)
- 改善異地字轉換，符合 OpenCC 臺灣標準 (例如 `啓` -> `啟`)
- 改善標點符號
- 新增 `wrong_beatmapset_state (authorization.php)` 翻譯
- 修正部份英文大小寫和英文版一樣
- 修正部份標點符號和英文版一樣